### PR TITLE
Fix: don't set width auto on all images

### DIFF
--- a/epub-modules/epub-fetch/src/models/iframe_zip_loader.js
+++ b/epub-modules/epub-fetch/src/models/iframe_zip_loader.js
@@ -169,9 +169,6 @@ define(['URIjs', 'bowser'], function(URI, bowser){
             var resolvedElems = $('img,svg', contentDocumentDom);
             if (resolvedElems.length === 1) {
                 var img = resolvedElems[0];
-                if (!img.hasAttribute("width")) {
-                    img.style.width = 'auto';
-                }
                 if (!img.hasAttribute("height")) {
                     img.style.height = 'auto';
                 }


### PR DESCRIPTION
It causes fixed layout epubs to crop images