### PR TITLE
Add: protection info in book metadata

### DIFF
--- a/js/epub-fetch/publication_fetcher.js
+++ b/js/epub-fetch/publication_fetcher.js
@@ -385,6 +385,7 @@ define(['jquery', 'URIjs', './markup_parser', './plain_resource_fetcher', './zip
 
                     // get LCP license
                     if (_encryptionHandler.isLcpEncryptionSpecified()) {
+                        packageMetadata.protection = 'LCP';
                         self.getLicenseLcp(function (license) {
                             _encryptionHandler.checkLicense(license, settingFinishedCallback, errorCb);
                         }, errorCb);


### PR DESCRIPTION
Ajout de l'info de protection du livre dans les metadata.
Cela ne s'applique qu'à LCP pour l'instant.

On se servira de cette information dans le WebReader pour savoir si il faut protéger le livre contre les clics droit et les drag & drop.

ping @oservieres et @K-Phoen 