### PR TITLE
Fix font cache system

### DIFF
--- a/js/epub-fetch/content_document_fetcher.js
+++ b/js/epub-fetch/content_document_fetcher.js
@@ -211,10 +211,13 @@ define(
 
 
                 if (cachedResourceURL) {
+                    var cssUrlFetchDeferred = $.Deferred();
+                    cssResourceDownloadDeferreds.push(cssUrlFetchDeferred);
                     stylesheetCssResourceUrlsMap[origMatchedUrlString] = {
                         isStyleSheetResource: isStyleSheetResource,
                         resourceObjectURL: cachedResourceURL
                     };
+                    cssUrlFetchDeferred.resolve();
                 } else {
                     var cssUrlFetchDeferred = $.Deferred();
                     cssResourceDownloadDeferreds.push(cssUrlFetchDeferred);

--- a/js/epub-fetch/content_document_fetcher.js
+++ b/js/epub-fetch/content_document_fetcher.js
@@ -211,13 +211,10 @@ define(
 
 
                 if (cachedResourceURL) {
-                    var cssUrlFetchDeferred = $.Deferred();
-                    cssResourceDownloadDeferreds.push(cssUrlFetchDeferred);
                     stylesheetCssResourceUrlsMap[origMatchedUrlString] = {
                         isStyleSheetResource: isStyleSheetResource,
                         resourceObjectURL: cachedResourceURL
                     };
-                    cssUrlFetchDeferred.resolve();
                 } else {
                     var cssUrlFetchDeferred = $.Deferred();
                     cssResourceDownloadDeferreds.push(cssUrlFetchDeferred);
@@ -289,32 +286,35 @@ define(
                 });
 
                 if (cssResourceDownloadDeferreds.length > 0) {
-                    $.when.apply($, cssResourceDownloadDeferreds).done(function () {
-                        for (var origMatchedUrlString in stylesheetCssResourceUrlsMap) {
-                            var processedResourceDescriptor = stylesheetCssResourceUrlsMap[origMatchedUrlString];
-
-
-                            var processedUrlString;
-                            if (processedResourceDescriptor.isStyleSheetResource) {
-                                processedUrlString = '@import "' + processedResourceDescriptor.resourceObjectURL + '"';
-                            } else {
-                                processedUrlString = "url('" + processedResourceDescriptor.resourceObjectURL + "')";
-                            }
-                            var origMatchedUrlStringEscaped = origMatchedUrlString.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g,
-                                "\\$&");
-                            var origMatchedUrlStringRegExp = new RegExp(origMatchedUrlStringEscaped, 'g');
-                            //noinspection JSCheckFunctionSignatures
-                            styleSheetResourceData =
-                                styleSheetResourceData.replace(origMatchedUrlStringRegExp, processedUrlString, 'g');
-
-                        }
-                        callback(styleSheetResourceData);
+                    $.when.apply($, cssResourceDownloadDeferreds).done(function() {
+                        replaceResourceUris(styleSheetResourceData, stylesheetCssResourceUrlsMap, callback);
                     });
                 } else {
-                    callback(styleSheetResourceData);
+                    replaceResourceUris(styleSheetResourceData, stylesheetCssResourceUrlsMap, callback);
                 }
             }
 
+            function replaceResourceUris(styleSheetResourceData, stylesheetCssResourceUrlsMap, callback) {
+                for (var origMatchedUrlString in stylesheetCssResourceUrlsMap) {
+                    var processedResourceDescriptor = stylesheetCssResourceUrlsMap[origMatchedUrlString];
+
+
+                    var processedUrlString;
+                    if (processedResourceDescriptor.isStyleSheetResource) {
+                        processedUrlString = '@import "' + processedResourceDescriptor.resourceObjectURL + '"';
+                    } else {
+                        processedUrlString = "url('" + processedResourceDescriptor.resourceObjectURL + "')";
+                    }
+                    var origMatchedUrlStringEscaped = origMatchedUrlString.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g,
+                        "\\$&");
+                    var origMatchedUrlStringRegExp = new RegExp(origMatchedUrlStringEscaped, 'g');
+                    //noinspection JSCheckFunctionSignatures
+                    styleSheetResourceData =
+                        styleSheetResourceData.replace(origMatchedUrlStringRegExp, processedUrlString, 'g');
+
+                }
+                callback(styleSheetResourceData);
+            }
 
             function resolveResourceElements(elemName, refAttr, fetchMode, resolutionDeferreds, onerror,
                                              resourceDataPreprocessing) {


### PR DESCRIPTION
Le système d'appel au cache pour les ressources appelées depuis les fichiers CSS d'un epub ne fonctionnait tout simplement pas. C'est trop long à expliquer ici mais je peux vous l'expliquer à l'oral au besoin.

Ce fix fait partie de la story [TEA-1133](https://tea-ebook.atlassian.net/browse/TEA-1133) : chevauchement du texte (une histoire de font et de cache donc).

ping @cGuille et @K-Phoen 